### PR TITLE
Fix bug in new task modal where title, description, and due date stay the same

### DIFF
--- a/client/src/components/NewTaskModal/index.js
+++ b/client/src/components/NewTaskModal/index.js
@@ -1,5 +1,5 @@
 import "./index.css";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useTasks } from "../../TaskProvider";
 import { createTask } from "../../services/task";
 
@@ -12,7 +12,18 @@ const NewTaskModal = ({ open, onClose }) => {
     const [desc, setDesc] = useState("");
     const [dueDate, setDueDate] = useState(undefined);
 
+    useEffect(() => {
+        setTitle("");
+        setDesc("");
+        setDueDate(undefined);
+        console.log(JSON.stringify({
+            title,
+            desc,
+            dueDate}));
+    }, [open]);
+
     if (!open) return null;
+
 
     return (
         <div className="modal" onClick={onClose}>


### PR DESCRIPTION
There is a bug where if you don't edit the inputs in the new task modal, the previous values for those inputs would be submitted. 

The fix is to reset the value of the inputs whenever the modal Is opened or closed.