### PR TITLE
Fix Scheduled Time Input

### DIFF
--- a/client/src/components/TaskModal/index.js
+++ b/client/src/components/TaskModal/index.js
@@ -12,7 +12,7 @@ import 'katex/dist/katex.min.css'
 import remarkGfm from "remark-gfm";
 
 const dateToDisplay = (date) => {
-    const newDate = new Date(new Date(date) - 5 * 60 * 60 * 1000);
+    const newDate = new Date(new Date(date) - 4 * 60 * 60 * 1000);
     return newDate.toISOString().slice(0, 16);
 }
 

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -73,7 +73,7 @@ export const displayToday = (task) => {
 }
 
 export const displayThisWeek = (task) => {
-    return (anyScheduledTimesThisWeek(task) && !isDueToday(task)) || (isDueThisWeek(task) && !anyScheduledTimesToday(task));
+    return (anyScheduledTimesThisWeek(task) || isDueThisWeek(task)) && !displayToday(task);
 }
 
 export const displayEventually = (task) => {


### PR DESCRIPTION
Fixed weird issues with inputting new scheduled times for existing tasks, where double-digit dates could not be input and times were displayed incorrectly but stored correctly internally.